### PR TITLE
fix(java8): restore JDK 8 compatibility by removing Java 9–11 APIs

### DIFF
--- a/src/main/java/blue/language/processor/ContractLoader.java
+++ b/src/main/java/blue/language/processor/ContractLoader.java
@@ -46,14 +46,14 @@ final class ContractLoader {
             if (contract instanceof ChannelContract) {
                 ChannelContract channel = (ChannelContract) contract;
                 if (!ProcessorContractConstants.isProcessorManagedChannel(channel)
-                        && registry.lookupChannel(channel.getClass()).isEmpty()) {
+                        && !registry.lookupChannel(channel.getClass()).isPresent()) {
                     throw new MustUnderstandFailureException(
                             "Unsupported contract type: " + channel.getClass().getName());
                 }
                 builder.addChannel(key, channel);
             } else if (contract instanceof HandlerContract) {
                 HandlerContract handler = (HandlerContract) contract;
-                if (registry.lookupHandler(handler.getClass()).isEmpty()) {
+                if (!registry.lookupHandler(handler.getClass()).isPresent()) {
                     throw new MustUnderstandFailureException(
                             "Unsupported contract type: " + handler.getClass().getName());
                 }

--- a/src/main/java/blue/language/processor/DocumentProcessingResult.java
+++ b/src/main/java/blue/language/processor/DocumentProcessingResult.java
@@ -2,6 +2,7 @@ package blue.language.processor;
 
 import blue.language.model.Node;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -18,12 +19,12 @@ public final class DocumentProcessingResult {
     private final String failureReason;
 
     private DocumentProcessingResult(Node document,
-                                     List<Node> triggeredEvents,
-                                     long totalGas,
-                                     boolean capabilityFailure,
-                                     String failureReason) {
+            List<Node> triggeredEvents,
+            long totalGas,
+            boolean capabilityFailure,
+            String failureReason) {
         this.document = document;
-        this.triggeredEvents = Collections.unmodifiableList(triggeredEvents);
+        this.triggeredEvents = Collections.unmodifiableList(new ArrayList<>(triggeredEvents));
         this.totalGas = totalGas;
         this.capabilityFailure = capabilityFailure;
         this.failureReason = failureReason;
@@ -32,12 +33,12 @@ public final class DocumentProcessingResult {
     public static DocumentProcessingResult of(Node document, List<Node> triggeredEvents, long totalGas) {
         Objects.requireNonNull(document, "document");
         Objects.requireNonNull(triggeredEvents, "triggeredEvents");
-        return new DocumentProcessingResult(document, List.copyOf(triggeredEvents), totalGas, false, null);
+        return new DocumentProcessingResult(document, new ArrayList<>(triggeredEvents), totalGas, false, null);
     }
 
     public static DocumentProcessingResult capabilityFailure(Node document, String reason) {
         Objects.requireNonNull(document, "document");
-        return new DocumentProcessingResult(document, List.of(), 0L, true, reason);
+        return new DocumentProcessingResult(document, Collections.emptyList(), 0L, true, reason);
     }
 
     public Node document() {

--- a/src/test/java/blue/language/processor/ContractMappingIntegrationTest.java
+++ b/src/test/java/blue/language/processor/ContractMappingIntegrationTest.java
@@ -16,8 +16,9 @@ import blue.language.processor.model.TriggeredEventChannel;
 import blue.language.utils.TypeClassResolver;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,7 +27,10 @@ class ContractMappingIntegrationTest {
 
     @Test
     void loadsAllContractsFromBlueYaml() throws Exception {
-        String yaml = Files.readString(Path.of("src/test/resources/processor/contracts/all-contracts.blue"));
+        String yaml = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/processor/contracts/all-contracts.blue")),
+                StandardCharsets.UTF_8
+        );
 
         Blue blue = new Blue();
         Node document = blue.yamlToNode(yaml);


### PR DESCRIPTION
- ContractLoader: replace Optional.isEmpty() with !isPresent().
- DocumentProcessingResult:
  - replace List.copyOf(...) with new ArrayList<>(...) defensive copy.
  - replace List.of() with Collections.emptyList().
  - keep immutability via Collections.unmodifiableList(new ArrayList<>(...)).
- No behavioral changes; only API substitutions for JDK 8.