### PR TITLE
ci: add rc release workflow

### DIFF
--- a/.github/scripts/prepare-rc-release.js
+++ b/.github/scripts/prepare-rc-release.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+const CZ_TOML = '.cz.toml';
+const BASE_REF = process.env.RC_BASE_REF || 'origin/master';
+const VALID_BUMPS = new Set(['major', 'minor', 'patch']);
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function readVersion(content) {
+  const match = content.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error('Could not find version in .cz.toml');
+  }
+  return match[1];
+}
+
+function parseVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-rc\.\d+)?$/);
+  if (!match) {
+    throw new Error(`Unsupported version format: ${version}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function increment(version, bump) {
+  if (bump === 'major') {
+    return { major: version.major + 1, minor: 0, patch: 0 };
+  }
+  if (bump === 'minor') {
+    return { major: version.major, minor: version.minor + 1, patch: 0 };
+  }
+  return { major: version.major, minor: version.minor, patch: version.patch + 1 };
+}
+
+function commitMessagesSince(ref) {
+  return git(['log', '--format=%B%x00', `${ref}..HEAD`])
+    .split('\0')
+    .map((message) => message.trim())
+    .filter(Boolean)
+    .filter((message) => !message.startsWith('chore: release '));
+}
+
+function bumpFromMessages(messages) {
+  const explicit = process.env.RC_BUMP;
+  if (explicit) {
+    if (!VALID_BUMPS.has(explicit)) {
+      throw new Error(`RC_BUMP must be one of: ${Array.from(VALID_BUMPS).join(', ')}`);
+    }
+    return explicit;
+  }
+
+  let bump = null;
+  for (const message of messages) {
+    const header = message.split(/\r?\n/, 1)[0];
+    if (/BREAKING CHANGE:/m.test(message) || /^[a-zA-Z]+(?:\([^)]*\))?!:/.test(header)) {
+      return 'major';
+    }
+    if (/^feat(?:\([^)]*\))?:/.test(header)) {
+      bump = bump === 'patch' || bump == null ? 'minor' : bump;
+    } else if (/^fix(?:\([^)]*\))?:/.test(header) && bump == null) {
+      bump = 'patch';
+    } else if (bump == null) {
+      bump = 'patch';
+    }
+  }
+
+  return bump || 'patch';
+}
+
+function latestRc(base) {
+  const output = git(['tag', '--list', `v${base}-rc.*`]);
+  if (!output) {
+    return 0;
+  }
+  return output
+    .split(/\r?\n/)
+    .map((tag) => tag.match(new RegExp(`^v${base.replaceAll('.', '\\.')}-rc\\.(\\d+)$`)))
+    .filter(Boolean)
+    .map((match) => Number(match[1]))
+    .reduce((max, value) => Math.max(max, value), 0);
+}
+
+function versionFromRef(ref) {
+  const content = git(['show', `${ref}:${CZ_TOML}`]);
+  return parseVersion(readVersion(content));
+}
+
+const currentContent = fs.readFileSync(CZ_TOML, 'utf8');
+const baseVersion = versionFromRef(BASE_REF);
+const messages = commitMessagesSince(BASE_REF);
+const bump = bumpFromMessages(messages);
+const targetBase = formatVersion(increment(baseVersion, bump));
+const nextVersion = `${targetBase}-rc.${latestRc(targetBase) + 1}`;
+
+const nextContent = currentContent.replace(
+  /^version\s*=\s*"[^"]+"/m,
+  `version = "${nextVersion}"`,
+);
+fs.writeFileSync(CZ_TOML, nextContent);
+
+console.log(`Base ref: ${BASE_REF}`);
+console.log(`Base version: ${formatVersion(baseVersion)}`);
+console.log(`Aggregate bump: ${bump}`);
+console.log(`Next RC version: ${nextVersion}`);
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${nextVersion}\n`);
+}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,13 +1,27 @@
-name: Release
+name: Release RC
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - next
+    paths:
+      - '.cz.toml'
+      - 'build.gradle'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/wrapper/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'src/**'
+
+env:
+  CI: true
+  GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
 jobs:
-  Release:
+  ReleaseRC:
+    if: "${{ startsWith(github.event.head_commit.message, 'chore: release ') == false }}"
     runs-on: ubuntu-latest
-    env:
-      CI: true
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -15,12 +29,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}
 
-      - name: Check if branch is master
-        run: |
-          if [[ "${GITHUB_REF##*/}" != "master" ]]; then
-            echo "This workflow can only be triggered for the master branch."
-            exit 1
-          fi
+      - name: Fetch master and tags
+        run: git fetch origin master:refs/remotes/origin/master --tags
 
       - name: Set up Java 8 test runtime
         uses: actions/setup-java@v3
@@ -36,10 +46,25 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-    
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Prepare RC version
+        id: version
+        run: node .github/scripts/prepare-rc-release.js
+
+      - name: Commit and tag RC version
+        run: |
+          git add .cz.toml
+          git commit -m "chore: release ${{ steps.version.outputs.version }}"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
+
       - name: Execute Gradle build
         run: ./gradlew clean build
-    
+
       - name: Execute Gradle publish
         run: ./gradlew publish
 
@@ -53,11 +78,14 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
         run: ./gradlew jreleaserFullRelease
 
+      - name: Push release commit and tag
+        run: git push origin HEAD:next --follow-tags
+
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts
+          name: rc-artifacts
           path: |
             build/libs
             build/publications


### PR DESCRIPTION
## Summary

Adds release-candidate publishing support for `blue-language-java`, modeled after `blue-repository-java` and adapted to this repository's current `master` default branch.

## Changes

- Add a `Release RC` workflow that runs on pushes to `next` for release-relevant Gradle/source changes.
- Add an RC preparation script that calculates the next `x.y.z-rc.N` version from commits since `origin/master`, updates `.cz.toml`, and emits the version for the workflow.
- Standardize release workflow GitHub token usage on `secrets.WORKFLOW_PAT` for checkout and JReleaser.

## Validation

- `node --check .github/scripts/prepare-rc-release.js`
- Ruby YAML parse for `.github/workflows/release.yml` and `.github/workflows/release-rc.yml`
- `./gradlew clean build`

## Notes

After this merges, create/push `next` from the updated `master` to enable the RC branch flow.