### PR TITLE
perf(processor): bound handler subtype lookup cache

### DIFF
--- a/src/main/java/blue/language/processor/ContractMatchingService.java
+++ b/src/main/java/blue/language/processor/ContractMatchingService.java
@@ -7,15 +7,26 @@ import blue.language.snapshot.FrozenNode;
 import blue.language.utils.FrozenTypeMatcher;
 import blue.language.utils.Types;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Shared matcher facade for contract-level event patterns.
  */
 public final class ContractMatchingService {
 
     private static final NodeProvider NO_REFERENCES = blueId -> null;
+    private static final int EVENT_SUBTYPE_CACHE_LIMIT = 256;
 
     private final Blue blue;
     private final FrozenTypeMatcher matcher;
+    private final Map<ReferenceSubtypeKey, Boolean> eventSubtypeCache =
+            new LinkedHashMap<ReferenceSubtypeKey, Boolean>(EVENT_SUBTYPE_CACHE_LIMIT, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<ReferenceSubtypeKey, Boolean> eldest) {
+                    return size() > EVENT_SUBTYPE_CACHE_LIMIT;
+                }
+            };
 
     public ContractMatchingService() {
         this(null);
@@ -34,9 +45,36 @@ public final class ContractMatchingService {
         if (eventType == null || expectedType == null) {
             return false;
         }
-        return blue != null
+        ReferenceSubtypeKey cacheKey = referenceSubtypeKey(eventType, expectedType);
+        if (cacheKey != null) {
+            synchronized (eventSubtypeCache) {
+                Boolean cached = eventSubtypeCache.get(cacheKey);
+                if (cached != null) {
+                    return cached;
+                }
+            }
+        }
+        boolean result = blue != null
                 ? blue.isNodeSubtypeOf(eventType, expectedType)
                 : Types.isSubtype(eventType, expectedType, NO_REFERENCES);
+        if (cacheKey != null) {
+            synchronized (eventSubtypeCache) {
+                eventSubtypeCache.put(cacheKey, result);
+            }
+        }
+        return result;
+    }
+
+    private ReferenceSubtypeKey referenceSubtypeKey(Node eventType, Node expectedType) {
+        if (!eventType.isReferenceOnly() || !expectedType.isReferenceOnly()) {
+            return null;
+        }
+        String eventBlueId = eventType.getBlueId();
+        String expectedBlueId = expectedType.getBlueId();
+        if (eventBlueId == null || expectedBlueId == null || eventBlueId.equals(expectedBlueId)) {
+            return null;
+        }
+        return new ReferenceSubtypeKey(eventBlueId, expectedBlueId);
     }
 
     public boolean matches(FrozenNode event, FrozenNode pattern) {
@@ -54,5 +92,33 @@ public final class ContractMatchingService {
             return false;
         }
         return matches(FrozenNode.fromResolvedNode(event), FrozenNode.fromResolvedNode(pattern));
+    }
+
+    private static final class ReferenceSubtypeKey {
+        private final String eventBlueId;
+        private final String expectedBlueId;
+
+        private ReferenceSubtypeKey(String eventBlueId, String expectedBlueId) {
+            this.eventBlueId = eventBlueId;
+            this.expectedBlueId = expectedBlueId;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof ReferenceSubtypeKey)) {
+                return false;
+            }
+            ReferenceSubtypeKey that = (ReferenceSubtypeKey) other;
+            return eventBlueId.equals(that.eventBlueId)
+                    && expectedBlueId.equals(that.expectedBlueId);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * eventBlueId.hashCode() + expectedBlueId.hashCode();
+        }
     }
 }

--- a/src/test/java/blue/language/processor/HandlerMatchContextSubtypeTest.java
+++ b/src/test/java/blue/language/processor/HandlerMatchContextSubtypeTest.java
@@ -72,7 +72,7 @@ class HandlerMatchContextSubtypeTest {
         assertEquals(2, provider.lookupCount());
 
         assertTrue(child.eventTypeIsSubtypeOf(reference(types.expectedId)));
-        assertEquals(4, provider.lookupCount());
+        assertEquals(2, provider.lookupCount());
     }
 
     @Test
@@ -81,6 +81,9 @@ class HandlerMatchContextSubtypeTest {
         CountingMapProvider provider = new CountingMapProvider(types.definitions);
         ContractMatchingService matching = new ContractMatchingService(new Blue(provider));
 
+        assertFalse(context(types.event(types.unrelatedSameShapeId), matching)
+                .eventTypeIsSubtypeOf(reference(types.expectedId)));
+        assertEquals(1, provider.lookupCount());
         assertFalse(context(types.event(types.unrelatedSameShapeId), matching)
                 .eventTypeIsSubtypeOf(reference(types.expectedId)));
         assertEquals(1, provider.lookupCount());
@@ -130,6 +133,27 @@ class HandlerMatchContextSubtypeTest {
         assertTrue(frozenContext.eventTypeIsSubtypeOf(reference(types.expectedId)));
         assertTrue(context(types.event(types.childId), matching)
                 .eventTypeIsSubtypeOf(reference(types.expectedId)));
+    }
+
+    @Test
+    void pureReferenceSubtypeCacheIsBoundedAndEvictsLeastRecentlyUsedPair() {
+        TypeFixture types = TypeFixture.create();
+        CountingMapProvider unavailable = new CountingMapProvider(Collections.<String, Node>emptyMap());
+        ContractMatchingService matching = new ContractMatchingService(new Blue(unavailable));
+        Node expected = reference(types.expectedId);
+
+        for (int index = 0; index < 257; index++) {
+            String unavailableId = BlueIdCalculator.calculateBlueId(
+                    new Node().name("Unavailable Event " + index));
+            assertFalse(context(new Node().type(reference(unavailableId)), matching)
+                    .eventTypeIsSubtypeOf(expected));
+        }
+        assertEquals(257, unavailable.lookupCount());
+
+        String firstId = BlueIdCalculator.calculateBlueId(new Node().name("Unavailable Event 0"));
+        assertFalse(context(new Node().type(reference(firstId)), matching)
+                .eventTypeIsSubtypeOf(expected));
+        assertEquals(258, unavailable.lookupCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- cache pure-reference handler subtype results in the Language matching service
- keep exact and materialized matching on the existing formal subtype path
- cap the access-ordered cache at 256 entries and cover warm hits plus LRU eviction

## Verification
- ./gradlew clean check jmhClasses